### PR TITLE
Added field types

### DIFF
--- a/osugo/gamemode.go
+++ b/osugo/gamemode.go
@@ -1,0 +1,21 @@
+package osugo
+
+// GameMode represents the game mode for a given score, beatmap, or query.
+type GameMode int
+
+const (
+	// Osu represents the osu! game mode.
+	Osu GameMode = iota
+	// Taiko represents the Taiko game mode.
+	Taiko
+	// CtB represents the Catch the Beat game mode.
+	CtB
+	// Mania represents the osu!mania game mode.
+	Mania
+)
+
+// GetName gets the string represenation for a GameMode.
+func (m GameMode) GetName() string {
+	modes := []string{"osu!", "Taiko", "Catch the Beat", "osu!mania"}
+	return modes[m]
+}

--- a/osugo/genre.go
+++ b/osugo/genre.go
@@ -1,0 +1,35 @@
+package osugo
+
+// Genre represents the genre a given song is categorized under.
+type Genre int
+
+const (
+	Any Genre = iota
+	Unspecified
+	VideoGame
+	Anime
+	Rock
+	Pop
+	Other
+	Novelty
+	HipHop Genre = iota + 1 // For some reason 8 was skipped. ??
+	Electronic
+)
+
+// GetName gets the string representation for a Genre.
+func (g Genre) GetName() string {
+	genres := []string{
+		"Any",
+		"Unspecified",
+		"Video Game",
+		"Anime",
+		"Rock",
+		"Pop",
+		"Other",
+		"Novelty",
+		"",
+		"Hip Hop",
+		"Electronic",
+	}
+	return genres[g]
+}

--- a/osugo/genre.go
+++ b/osugo/genre.go
@@ -1,16 +1,16 @@
 package osugo
 
-// Genre represents the genre a given song is categorized under.
+// Genre is an ID represents the genre a given song is categorized under.
 type Genre int
 
 const (
-	Any Genre = iota
+	AnyGenre Genre = iota
 	Unspecified
 	VideoGame
 	Anime
 	Rock
 	Pop
-	Other
+	OtherGenre
 	Novelty
 	HipHop Genre = iota + 1 // For some reason 8 was skipped. ??
 	Electronic

--- a/osugo/language.go
+++ b/osugo/language.go
@@ -1,0 +1,38 @@
+package osugo
+
+// Language is an ID that represents a given language.
+type Language int
+
+const (
+	AnyLanguage Language = iota
+	OtherLanguage
+	English
+	Japanese
+	Chinese
+	Instrumental
+	Korean
+	French
+	German
+	Swedish
+	Spanish
+	Italian
+)
+
+// GetName gets the string representation for a Language.
+func (l Language) GetName() string {
+	langs := []string{
+		"Any Language",
+		"Other Language",
+		"English",
+		"Japanese",
+		"Chinese",
+		"Instrumental",
+		"Korean",
+		"French",
+		"German",
+		"Swedish",
+		"Spanish",
+		"Italian",
+	}
+	return langs[l]
+}

--- a/osugo/mods.go
+++ b/osugo/mods.go
@@ -1,0 +1,44 @@
+package osugo
+
+type Mod int
+
+const (
+	ModNone   Mod = 0
+	ModNoFail Mod = 1 << iota
+	ModEasy
+	ModTouchDevice
+	ModHidden
+	ModHardRock
+	ModSuddenDeath
+	ModDoubleTime
+	ModRelax
+	ModHalfTime
+	ModNightcore
+	ModFlashlight
+	ModAutoplay
+	ModSpunOut
+	ModRelax2
+	ModPerfect
+	ModKey4
+	ModKey5
+	ModKey6
+	ModKey7
+	ModKey8
+	ModFadeIn
+	ModRandom
+	ModCinema
+	ModTarget
+	ModKey9
+	ModKeyCoop
+	ModKey1
+	ModKey3
+	ModKey2
+	ModScoreV2
+	ModLastMod
+	ModKeyMod            Mod = ModKey1 | ModKey2 | ModKey3 | ModKey4 | ModKey5 | ModKey6 | ModKey7 | ModKey8 | ModKey9 | ModKeyCoop
+	ModFreeModAllowed    Mod = ModNoFail | ModEasy | ModHidden | ModHardRock | ModSuddenDeath | ModFlashlight | ModFadeIn | ModRelax | ModRelax2 | ModSpunOut | ModKeyMod
+	ModScoreIncreaseMods Mod = ModHidden | ModHardRock | ModDoubleTime | ModFlashlight | ModFadeIn
+)
+
+// Getting the string representation of the Mods will be done somewhere else since scores can have
+// more than 1 mod applied to it.

--- a/osugo/usertype.go
+++ b/osugo/usertype.go
@@ -1,0 +1,13 @@
+package osugo
+
+// UserType indicates if a given user's value was their username or user ID.
+//
+// This is used as an optional parameter for queries that ask for a user's name or ID.
+type UserType string
+
+const (
+	// Username indicates the value used for the user parameter was a username.
+	Username UserType = "string"
+	// ID indicates the value used for the user parameter was a user ID.
+	ID UserType = "id"
+)


### PR DESCRIPTION
Field types are osu!-specific types that are found in responses returned from the API. These included the game mode associated with some piece of data, the genre for a beatmap, the language set for a beatmap, and the mods applied to a score.